### PR TITLE
Make application deployable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Bash:
 ```shell
 ./scripts/run.sh
 ```
+
+## Deploy
+
+See the deployment [README.md](./deploy/README.md)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,9 +12,12 @@ Use your preferred cloud provider to create a Debian VM instance. Enable HTTP/HT
 ## Clone repository and install
 
 ```shell
+sudo apt update
+sudo apt upgrade -y
 sudo apt install git -y
 sudo git clone https://github.com/ndswecker/SnatchItCore.git /srv/web
 sudo bash /srv/web/deploy/install.sh
+sudo /srv/web/venv/bin/python3 /srv/web/app/manage.py createsuperuser
 ```
 
 ### Private repository

--- a/deploy/app.sh
+++ b/deploy/app.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+apt install python3-venv -y
+
+python3 -m venv /srv/web/venv
+/srv/web/venv/bin/python3 -m pip install pip setuptools wheel --upgrade --no-cache-dir
+/srv/web/venv/bin/python3 -m pip install -r /srv/web/requirements/prod.txt --upgrade --no-cache-dir
+cp /srv/web/envs/prod.env /srv/web/.env
+SECRET_KEY=$(python3 -c "import secrets;print(secrets.token_urlsafe(64))")
+sed -i "s/<SECRET_KEY>/$SECRET_KEY/g" /srv/web/.env
+/srv/web/venv/bin/python3 /srv/web/app/manage.py collectstatic
+/srv/web/venv/bin/python3 /srv/web/app/manage.py migrate

--- a/deploy/gunicorn.service
+++ b/deploy/gunicorn.service
@@ -8,11 +8,12 @@ Type=notify
 DynamicUser=yes
 RuntimeDirectory=gunicorn
 WorkingDirectory=/srv/web/
-ExecStart=/srv/web/venv/bin/gunicorn --chdir /srv/web/app/ core.wsgi:application
+ExecStart=/srv/web/venv/bin/gunicorn --config /srv/web/gunicorn.conf.py --chdir /srv/web/app/ core.wsgi:application
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5
 PrivateTmp=true
+User=www-data
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/gunicorn.sh
+++ b/deploy/gunicorn.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+cp /srv/web/deploy/gunicorn.service /etc/systemd/system/gunicorn.service
+cp /srv/web/deploy/gunicorn.socket /etc/systemd/system/gunicorn.socket
+systemctl daemon-reload
+systemctl start gunicorn.socket
+systemctl enable gunicorn.socket

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -4,28 +4,17 @@
 apt update
 apt upgrade -y
 
-# Install dependencies
-apt install nginx python3-venv -y
+# Configure UFW
+source /srv/web/deploy/ufw.sh
+
+# Create database
+source /srv/web/deploy/postgres.sh
 
 # Install application
-python3 -m venv /srv/web/venv
-/srv/web/venv/bin/python3 -m pip install pip setuptools wheel --upgrade --no-cache-dir
-/srv/web/venv/bin/python3 -m pip install -r /srv/web/requirements/prod.txt --upgrade --no-cache-dir
-cp /srv/web/envs/prod.env /srv/web/.env
-SECRET_KEY=$(python3 -c "import secrets;print(secrets.token_urlsafe(64))")
-sed -i "s/<SECRET_KEY>/$SECRET_KEY/g" /srv/web/.env
-/srv/web/venv/bin/python3 /srv/web/app/manage.py collectstatic
-/srv/web/venv/bin/python3 /srv/web/app/manage.py migrate
+source /srv/web/deploy/app.sh
 
 # Create gunicorn socket and service
-cp /srv/web/deploy/gunicorn.service /etc/systemd/system/gunicorn.service
-cp /srv/web/deploy/gunicorn.socket /etc/systemd/system/gunicorn.socket
-systemctl daemon-reload
-systemctl start gunicorn.socket
-systemctl enable gunicorn.socket
+source /srv/web/deploy/gunicorn.sh
 
 # Configure NGINX
-cp /srv/web/deploy/app.conf /etc/nginx/conf.d/app.conf
-PUBLIC_IP=$(curl -s -4 ifconfig.me)
-sed -i "s/server_name ~^.+$;/server_name $PUBLIC_IP;/" /etc/nginx/conf.d/app.conf
-systemctl restart nginx
+source /srv/web/deploy/nginx.sh

--- a/deploy/nginx.sh
+++ b/deploy/nginx.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+apt install nginx -y
+
+cp /srv/web/deploy/app.conf /etc/nginx/conf.d/app.conf
+PUBLIC_IP=$(curl -s -4 ifconfig.me)
+sed -i "s/server_name ~^.+$;/server_name $PUBLIC_IP;/" /etc/nginx/conf.d/app.conf
+systemctl restart nginx

--- a/deploy/postgres.sh
+++ b/deploy/postgres.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+apt install postgresql -y
+
+sudo -u postgres psql -c "CREATE DATABASE web;"
+sudo -u postgres psql -c "CREATE USER \"www-data\" WITH ENCRYPTED PASSWORD 'pass';"
+sudo -u postgres psql -c "ALTER DATABASE web OWNER TO \"www-data\";"

--- a/deploy/timers/example.service
+++ b/deploy/timers/example.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Example Service
+
+[Service]
+ExecStart=/srv/web/venv/bin/python3 /srv/web/app/manage.py example_command
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/timers/example.timer
+++ b/deploy/timers/example.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Example Service
+
+[Timer]
+OnCalendar=Tue 11:20:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ufw.sh
+++ b/deploy/ufw.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+apt install ufw -y
+
+ufw --force disable
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow ssh
+ufw allow http
+ufw allow https
+sed -i "s/IPV6=no/IPV6=yes/" /etc/default/ufw
+ufw --force disable
+ufw --force enable
+systemctl restart ufw

--- a/envs/prod.env
+++ b/envs/prod.env
@@ -1,6 +1,6 @@
 ALLOWED_HOSTS=*
 CSRF_COOKIE_SECURE=False
-DATABASE_URL=sqlite:///db.sqlite3
+DATABASE_URL=postgres://www-data:pass@localhost:5432/web
 DEBUG=0
 SECURE_HSTS_SECONDS=0
 SECRET_KEY=<SECRET_KEY>

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,1 @@
+user = "www-data"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,4 @@
 -r base.txt
 
 gunicorn
+psycopg2-binary


### PR DESCRIPTION
Make the application immediately deployable.

These changes make the application immediately deployable to a Debian server with a Postgres database instance locally.

The installation script has been split to simplify the process of switching from a local Postgres database server to another local DB provider or to an external DB provider.